### PR TITLE
Add support for transactionOrigin

### DIFF
--- a/__tests__/06_opts_spec.ts
+++ b/__tests__/06_opts_spec.ts
@@ -1,0 +1,42 @@
+import * as Y from 'yjs';
+import { proxy } from 'valtio/vanilla';
+import { bindProxyAndYArray, bindProxyAndYMap } from '../src/index';
+
+describe('bindProxyAndYMap options', () => {
+  it('simple map', async () => {
+    const doc = new Y.Doc();
+    const p = proxy<{ foo?: string }>({});
+    const m = doc.getMap('map');
+
+    bindProxyAndYMap(p, m, { transactionOrigin: 'valtio-yjs' });
+
+    const fn = jest.fn();
+    doc.on('updateV2', (_: Uint8Array, origin: any) => {
+      fn(origin);
+    });
+
+    p.foo = 'bar';
+    await Promise.resolve();
+
+    expect(fn).toBeCalledWith('valtio-yjs');
+  });
+});
+
+describe('bindProxyAndYArray', () => {
+  it('simple array', async () => {
+    const doc = new Y.Doc();
+    const p = proxy<string[]>([]);
+    const a = doc.getArray<string>('arr');
+
+    const fn = jest.fn();
+    doc.on('updateV2', (_: Uint8Array, origin: any) => {
+      fn(origin);
+    });
+
+    bindProxyAndYArray(p, a, { transactionOrigin: 'valtio-yjs' });
+
+    p.push('a');
+    await Promise.resolve();
+    expect(fn).toBeCalledWith('valtio-yjs');
+  });
+});

--- a/__tests__/06_opts_spec.ts
+++ b/__tests__/06_opts_spec.ts
@@ -3,7 +3,7 @@ import { proxy } from 'valtio/vanilla';
 import { bindProxyAndYArray, bindProxyAndYMap } from '../src/index';
 
 describe('bindProxyAndYMap options', () => {
-  it('simple map', async () => {
+  it('transactionOrigin is included in Y.Doc events', async () => {
     const doc = new Y.Doc();
     const p = proxy<{ foo?: string }>({});
     const m = doc.getMap('map');
@@ -23,7 +23,7 @@ describe('bindProxyAndYMap options', () => {
 });
 
 describe('bindProxyAndYArray', () => {
-  it('simple array', async () => {
+  it('transactionOrigin is included in Y.Doc events', async () => {
     const doc = new Y.Doc();
     const p = proxy<string[]>([]);
     const a = doc.getArray<string>('arr');


### PR DESCRIPTION
YJS supports an optional `transactionOrigin` property. Add support for it to valtio-yjs.