### PR TITLE
Fix infinite loop when replacing an array inside a nested map

### DIFF
--- a/__tests__/07_nested_map_spec.ts
+++ b/__tests__/07_nested_map_spec.ts
@@ -41,4 +41,19 @@ describe('issue #14', () => {
 
     expect(m.get('items').get('item1').get('color')).toStrictEqual('red');
   });
+
+  it('nested map array property replace', async () => {
+    const doc = new Y.Doc();
+    const p = proxy({ items: { item1: { point: [0, 0] } } });
+    const m = doc.getMap('map');
+
+    bindProxyAndYMap(p, m);
+
+    p.items.item1.point = [100, 100];
+    await Promise.resolve();
+
+    expect(m.get('items').get('item1').get('point').toJSON()).toStrictEqual([
+      100, 100,
+    ]);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ export const bindProxyAndYMap = <T>(
       } else if (op[0] === 'set') {
         const pv = p[k];
         const yv = y.get(k);
-        if (!deepEqual(yv instanceof Y.Map ? yv.toJSON() : yv, pv)) {
+        if (!deepEqual(yv instanceof Y.AbstractType ? yv.toJSON() : yv, pv)) {
           setPValueToY(pv, k);
         }
       }


### PR DESCRIPTION
Another special case of https://github.com/dai-shi/valtio-yjs/issues/14 is when the property of the nested map is an array – even with the fix from https://github.com/dai-shi/valtio-yjs/pull/15, this case still sent the library to an infinite loop.

This PR extends the deep equality check added in #15 compare `Y.Array` (and other YJS shared types that inherit from `Y.AbstractType`) in addition to `Y.Map`.

## Test plan

Added a new test case where the nested property is an array.