### PR TITLE
Allow variable transactionOrigin value

### DIFF
--- a/__tests__/06_opts_spec.ts
+++ b/__tests__/06_opts_spec.ts
@@ -8,7 +8,7 @@ describe('bindProxyAndYMap options', () => {
     const p = proxy<{ foo?: string }>({});
     const m = doc.getMap('map');
 
-    bindProxyAndYMap(p, m, { transactionOrigin: 'valtio-yjs' });
+    bindProxyAndYMap(p, m, { transactionOrigin: () => 'valtio-yjs' });
 
     const fn = jest.fn();
     doc.on('updateV2', (_: Uint8Array, origin: any) => {
@@ -33,7 +33,7 @@ describe('bindProxyAndYArray', () => {
       fn(origin);
     });
 
-    bindProxyAndYArray(p, a, { transactionOrigin: 'valtio-yjs' });
+    bindProxyAndYArray(p, a, { transactionOrigin: () => 'valtio-yjs' });
 
     p.push('a');
     await Promise.resolve();

--- a/__tests__/06_opts_spec.ts
+++ b/__tests__/06_opts_spec.ts
@@ -8,7 +8,14 @@ describe('bindProxyAndYMap options', () => {
     const p = proxy<{ foo?: string }>({});
     const m = doc.getMap('map');
 
-    bindProxyAndYMap(p, m, { transactionOrigin: () => 'valtio-yjs' });
+    let counter = 0;
+    bindProxyAndYMap(p, m, {
+      transactionOrigin: () => {
+        const id = counter;
+        counter += 1;
+        return { id };
+      },
+    });
 
     const fn = jest.fn();
     doc.on('updateV2', (_: Uint8Array, origin: any) => {
@@ -17,8 +24,12 @@ describe('bindProxyAndYMap options', () => {
 
     p.foo = 'bar';
     await Promise.resolve();
+    expect(fn).toBeCalledWith({ id: 0 });
+    fn.mockClear();
 
-    expect(fn).toBeCalledWith('valtio-yjs');
+    p.foo = 'baz';
+    await Promise.resolve();
+    expect(fn).toBeCalledWith({ id: 1 });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,9 @@ type Options = {
   transactionOrigin?: () => any;
 };
 
-const transact = (
-  doc: Y.Doc | null,
-  transactionOrigin: any,
-  fn: () => void,
-) => {
+const transact = (doc: Y.Doc | null, opts: Options, fn: () => void) => {
   if (doc) {
-    doc.transact(fn, transactionOrigin);
+    doc.transact(fn, opts.transactionOrigin?.());
   } else {
     fn();
   }
@@ -36,11 +32,10 @@ export const bindProxyAndYMap = <T>(
   y: Y.Map<T>,
   opts: Options = {},
 ) => {
-  const transactionOrigin = opts.transactionOrigin ?? (() => null);
   const pv2yvCache = new WeakMap<object, unknown>();
 
   const setPValueToY = (pv: T, k: string) => {
-    transact(y.doc, transactionOrigin(), () => {
+    transact(y.doc, opts, () => {
       if (
         isObject(pv) &&
         pv2yvCache.has(pv) &&
@@ -172,7 +167,6 @@ export const bindProxyAndYArray = <T>(
   y: Y.Array<T>,
   opts: Options = {},
 ) => {
-  const transactionOrigin = opts.transactionOrigin ?? (() => null);
   const pv2yvCache = new WeakMap<object, unknown>();
 
   const insertPValueToY = (pv: T, i: number) => {
@@ -286,7 +280,7 @@ export const bindProxyAndYArray = <T>(
     if (deepEqual(y.toJSON(), p)) {
       return;
     }
-    transact(y.doc, transactionOrigin(), () => {
+    transact(y.doc, opts, () => {
       arrayOps.forEach((op) => {
         const i = op[1];
         if (op[0] === 'delete') {


### PR DESCRIPTION
We needed `transactionOrigin` to be variable per transaction so that we can include a transaction ID in it (used to selectively apply updates from different sources).

This PR changes the `transactionOrigin` option to be a function that's called to get the value used as origin for each transaction.

I could have made this change in a backwards compatible way by allowing the option to be either the origin itself or the function returning it, but I opted to change the API instead, because having this kind of arguments is often a source of accidental complexity in libraries that accept a number of options. Additionally, allowing both values and functions could have had unexpected results, if you try to set the origin to be a function (e.g. a constructor, something I've seen used in the YJS codebase).