### PR TITLE
Pass transactionOrigin function through without calling it

### DIFF
--- a/__tests__/06_opts_spec.ts
+++ b/__tests__/06_opts_spec.ts
@@ -8,13 +8,15 @@ describe('bindProxyAndYMap options', () => {
     const p = proxy<{ foo?: string }>({});
     const m = doc.getMap('map');
 
+    const transactionOrigin = () => {
+      const id = counter;
+      counter += 1;
+      return { id };
+    };
+
     let counter = 0;
     bindProxyAndYMap(p, m, {
-      transactionOrigin: () => {
-        const id = counter;
-        counter += 1;
-        return { id };
-      },
+      transactionOrigin,
     });
 
     const fn = jest.fn();
@@ -24,12 +26,12 @@ describe('bindProxyAndYMap options', () => {
 
     p.foo = 'bar';
     await Promise.resolve();
-    expect(fn).toBeCalledWith({ id: 0 });
+    expect(fn).toBeCalledWith(transactionOrigin);
     fn.mockClear();
 
     p.foo = 'baz';
     await Promise.resolve();
-    expect(fn).toBeCalledWith({ id: 1 });
+    expect(fn).toBeCalledWith(transactionOrigin);
   });
 });
 
@@ -44,10 +46,12 @@ describe('bindProxyAndYArray', () => {
       fn(origin);
     });
 
-    bindProxyAndYArray(p, a, { transactionOrigin: () => 'valtio-yjs' });
+    const transactionOrigin = () => 'valtio-yjs';
+
+    bindProxyAndYArray(p, a, { transactionOrigin });
 
     p.push('a');
     await Promise.resolve();
-    expect(fn).toBeCalledWith('valtio-yjs');
+    expect(fn).toBeCalledWith(transactionOrigin);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,12 @@ const isPrimitiveArrayValue = (v: unknown) =>
   typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
 
 type Options = {
-  transactionOrigin?: () => any;
+  transactionOrigin?: any;
 };
 
 const transact = (doc: Y.Doc | null, opts: Options, fn: () => void) => {
   if (doc) {
-    doc.transact(fn, opts.transactionOrigin?.());
+    doc.transact(fn, opts.transactionOrigin);
   } else {
     fn();
   }


### PR DESCRIPTION
Let library users decide when the transactionOrigin is called, vs calling it in valtio-yjs. Also accept any type of 
transactionOrigin.

More flexible, and in most cases transactionOrgin is a property used by a YJS Provider (internally) anyway.